### PR TITLE
removing validation

### DIFF
--- a/lib/mongoose-user.js
+++ b/lib/mongoose-user.js
@@ -160,36 +160,4 @@ function userPlugin (schema, options) {
     return this._password
   })
 
-  /**
-   * Skip validation virtual.
-   *
-   * If skipValidation attribute is set to true, validations won't be performed
-   */
-
-  schema.virtual('skipValidation')
-  .set(function(val) {
-    this._skipValidation = val
-  })
-  .get(function() {
-    return this._skipValidation
-  })
-
-  /**
-   * Validations
-   */
-
-  schema.path('name').validate(function (name) {
-    if (this.skipValidation) return true
-    return name.trim().length
-  }, 'Please provide a valid name')
-
-  schema.path('email').validate(function (email) {
-    if (this.skipValidation) return true
-    return email.trim().length
-  }, 'Please provide a valid email')
-
-  schema.path('hashed_password').validate(function (hashed_password) {
-    if (this.skipValidation) return true
-    return hashed_password.length
-  }, 'Please provide a password')
 }


### PR DESCRIPTION
The validation makes assumptions about the properties of a user object.
I think it would be better to avoid such assumptions. The only way to create a user model without an email address would be to skip validation and that is also hacky.